### PR TITLE
fix: TS2802

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 -------------------------------
 <a name="start"></a>
 
+### v1.3.0
+
+- Canceled removing Array-methods from `OpenPromise` type for modern TS
+- Add `readonly` in `OpenPromise`
+
+---
+
 ### v1.2.0
 
 - Support `AbortController`

--- a/src/open/promise.ts
+++ b/src/open/promise.ts
@@ -4,10 +4,10 @@ type NotReadonly<T> = {-readonly [P in keyof T]: T[P]};
 
 /** OpenPromise Object */
 export type OpenPromise<T> = readonly [
-    Promise<T>,
-    (value: T) => void,
-    (reason: unknown) => void,
-    AbortController,
+    promise: Promise<T>,
+    resolve: (value: T) => void,
+    reject: (reason: unknown) => void,
+    controller: AbortController,
 ] & {
     readonly state: 'pending' | 'fulfilled' | 'rejected';
     readonly promise: Promise<T>;

--- a/src/open/promise.ts
+++ b/src/open/promise.ts
@@ -1,17 +1,19 @@
 const STATE_PENDING = 'pending';
 
+type NotReadonly<T> = {-readonly [P in keyof T]: T[P]};
+
 /** OpenPromise Object */
-export type OpenPromise<T> = Omit<[
+export type OpenPromise<T> = readonly [
     Promise<T>,
     (value: T) => void,
     (reason: unknown) => void,
     AbortController,
-], Extract<keyof Array<unknown>, string>> & {
-    state: 'pending' | 'fulfilled' | 'rejected';
-    promise: Promise<T>;
-    resolve: (value: T) => void;
-    reject: (reason: unknown) => void;
-    controller: AbortController;
+] & {
+    readonly state: 'pending' | 'fulfilled' | 'rejected';
+    readonly promise: Promise<T>;
+    readonly resolve: (value: T) => void;
+    readonly reject: (reason: unknown) => void;
+    readonly controller: AbortController;
 };
 
 /** Create OpenPromise */
@@ -23,7 +25,7 @@ export const createOpenPromise = <T>(
     ) => T,
 ): OpenPromise<Awaited<T>> => {
     // Create OpenTuple
-    const open = Array(4) as unknown as OpenPromise<Awaited<T>>;
+    const open = Array(4) as unknown as NotReadonly<OpenPromise<Awaited<T>>>;
 
     // Lazy AbortController (to not care about of polyfill)
     let controller: AbortController | undefined;


### PR DESCRIPTION
> Итерация типа "OpenPromise" может осуществляться только с использованием флага "--downlevelIteration" или с параметром "--target" "es2015" или выше.

<img width="1073" alt="Снимок экрана 2024-03-31 в 20 23 31" src="https://github.com/RubaXa/open-promise/assets/93006259/60744a14-9826-4f44-9780-2ee01740b05f">

Круто что сейчас удаляется всё не нужное и остается в массиве только "рожки да ножки", но TS ругается c ошибкой `TS2802`

В типах вернул свойства массива, но накинул на всё `readonly` как этакий компромис 